### PR TITLE
checking vault token_helper for previous vault token if envar not set

### DIFF
--- a/vault.go
+++ b/vault.go
@@ -3,9 +3,11 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"regexp"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/go-homedir"
 )
 
 // Vault : Handles a Vault API Client and a TransitKey name
@@ -33,7 +35,13 @@ func (v *Vault) ConfigureClient(address, token string) error {
 	}
 
 	if len(token) == 0 {
-		return fmt.Errorf("Vault token is not defined")
+		home, _ := homedir.Dir()
+		f, err := ioutil.ReadFile(home + "/.vault-token")
+		if err != nil {
+			return fmt.Errorf("Vault token is not defined")
+		}
+
+		token = string(f)
 	}
 
 	v.Client.SetAddress(address)


### PR DESCRIPTION
Doesn't require VAULT_TOKEN to be defined if you have logged in from the cli previously 