### PR TITLE
Implemented stdin capabilities for cipher/decipher functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### FEATURES
+- We can now pass text through `stdin` as well as an argument for cipher/decipher functions
 
 ## [0.1.1] - 2018-07-10
 ### FEATURES


### PR DESCRIPTION
This is a new feature allowing us to leverage stdin to pass values for cipher and decipher functions:

```
~$ echo "I LOVE BANANAS" | s5 cipher | s5 decipher
I LOVE BANANAS
```