### PR TITLE
ci: install Goreleaser to fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - 'v[0-9]+.[0-9]+.[0-9]+'
     branches:
       - main
 
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      DOCKER_CLI_EXPERIMENTAL: "enabled"
+      DOCKER_CLI_EXPERIMENTAL: 'enabled'
 
     steps:
       - name: Checkout
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: "1.22"
+          go-version: '1.22'
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,9 @@ jobs:
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Install goreleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
-          version: v1.24.0
+          version: v2.3.2
           install-only: true
 
       - name: Run goreleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
     branches:
       - main
 
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
-      DOCKER_CLI_EXPERIMENTAL: 'enabled'
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
 
     steps:
       - name: Checkout
@@ -54,13 +54,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
         with:
-          go-version: '1.22'
+          go-version: "1.22"
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Install goreleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: v1.24.0
+          install-only: true
 
       - name: Run goreleaser
         run: make ${{ github.ref == 'refs/heads/main' && 'pre' || '' }}release

--- a/.goreleaser.pre.yml
+++ b/.goreleaser.pre.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - make man-pages
@@ -31,7 +32,7 @@ universal_binaries:
   - {}
 
 archives:
-  - name_template: '{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - name_template: "{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
         format: zip
@@ -46,7 +47,7 @@ nfpms:
     license: Apache-2.0
     homepage: https://github.com/mvisonneau/s5
     vendor: *author
-    file_name_template: '{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    file_name_template: "{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     bindir: /usr/local/bin
     formats:
       - apk
@@ -58,7 +59,7 @@ nfpms:
         file_info:
           mode: 0644
       - src: ./helpers/autocomplete/zsh
-        dst:  /usr/share/zsh/vendor-completions/_{{ .ProjectName }}
+        dst: /usr/share/zsh/vendor-completions/_{{ .ProjectName }}
         file_info:
           mode: 0644
       - src: ./helpers/manpages/{{ .ProjectName }}.1.gz
@@ -86,9 +87,9 @@ snapcrafts:
 
 dockers:
   - image_templates:
-      - 'docker.io/mvisonneau/s5:latest-amd64'
-      - 'ghcr.io/mvisonneau/s5:latest-amd64'
-      - 'quay.io/mvisonneau/s5:latest-amd64'
+      - "docker.io/mvisonneau/s5:latest-amd64"
+      - "ghcr.io/mvisonneau/s5:latest-amd64"
+      - "quay.io/mvisonneau/s5:latest-amd64"
     ids: [s5]
     goarch: amd64
     use: buildx
@@ -104,9 +105,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - 'docker.io/mvisonneau/s5:latest-arm64'
-      - 'ghcr.io/mvisonneau/s5:latest-arm64'
-      - 'quay.io/mvisonneau/s5:latest-arm64'
+      - "docker.io/mvisonneau/s5:latest-arm64"
+      - "ghcr.io/mvisonneau/s5:latest-arm64"
+      - "quay.io/mvisonneau/s5:latest-arm64"
     ids: [s5]
     goarch: arm64
     use: buildx
@@ -122,9 +123,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - 'docker.io/mvisonneau/s5:latest-armv6'
-      - 'ghcr.io/mvisonneau/s5:latest-armv6'
-      - 'quay.io/mvisonneau/s5:latest-armv6'
+      - "docker.io/mvisonneau/s5:latest-armv6"
+      - "ghcr.io/mvisonneau/s5:latest-armv6"
+      - "quay.io/mvisonneau/s5:latest-armv6"
     ids: [s5]
     goarch: arm
     goarm: 6
@@ -141,9 +142,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - 'docker.io/mvisonneau/s5:latest-armv7'
-      - 'ghcr.io/mvisonneau/s5:latest-armv7'
-      - 'quay.io/mvisonneau/s5:latest-armv7'
+      - "docker.io/mvisonneau/s5:latest-armv7"
+      - "ghcr.io/mvisonneau/s5:latest-armv7"
+      - "quay.io/mvisonneau/s5:latest-armv7"
     ids: [s5]
     goarch: arm
     goarm: 7
@@ -185,16 +186,16 @@ signs:
   - artifacts: checksum
     args:
       [
-        '-u',
-        'C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE',
-        '--output',
-        '${signature}',
-        '--detach-sign',
-        '${artifact}',
+        "-u",
+        "C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE",
+        "--output",
+        "${signature}",
+        "--detach-sign",
+        "${artifact}",
       ]
 
 checksum:
-  name_template: '{{ .ProjectName }}_edge_sha512sums.txt'
+  name_template: "{{ .ProjectName }}_edge_sha512sums.txt"
   algorithm: sha512
 
 changelog:

--- a/.goreleaser.pre.yml
+++ b/.goreleaser.pre.yml
@@ -32,7 +32,7 @@ universal_binaries:
   - {}
 
 archives:
-  - name_template: "{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - name_template: '{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip
@@ -47,7 +47,7 @@ nfpms:
     license: Apache-2.0
     homepage: https://github.com/mvisonneau/s5
     vendor: *author
-    file_name_template: "{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    file_name_template: '{{ .ProjectName }}_edge_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     bindir: /usr/local/bin
     formats:
       - apk
@@ -87,9 +87,9 @@ snapcrafts:
 
 dockers:
   - image_templates:
-      - "docker.io/mvisonneau/s5:latest-amd64"
-      - "ghcr.io/mvisonneau/s5:latest-amd64"
-      - "quay.io/mvisonneau/s5:latest-amd64"
+      - 'docker.io/mvisonneau/s5:latest-amd64'
+      - 'ghcr.io/mvisonneau/s5:latest-amd64'
+      - 'quay.io/mvisonneau/s5:latest-amd64'
     ids: [s5]
     goarch: amd64
     use: buildx
@@ -105,9 +105,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - "docker.io/mvisonneau/s5:latest-arm64"
-      - "ghcr.io/mvisonneau/s5:latest-arm64"
-      - "quay.io/mvisonneau/s5:latest-arm64"
+      - 'docker.io/mvisonneau/s5:latest-arm64'
+      - 'ghcr.io/mvisonneau/s5:latest-arm64'
+      - 'quay.io/mvisonneau/s5:latest-arm64'
     ids: [s5]
     goarch: arm64
     use: buildx
@@ -123,9 +123,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - "docker.io/mvisonneau/s5:latest-armv6"
-      - "ghcr.io/mvisonneau/s5:latest-armv6"
-      - "quay.io/mvisonneau/s5:latest-armv6"
+      - 'docker.io/mvisonneau/s5:latest-armv6'
+      - 'ghcr.io/mvisonneau/s5:latest-armv6'
+      - 'quay.io/mvisonneau/s5:latest-armv6'
     ids: [s5]
     goarch: arm
     goarm: 6
@@ -142,9 +142,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - "docker.io/mvisonneau/s5:latest-armv7"
-      - "ghcr.io/mvisonneau/s5:latest-armv7"
-      - "quay.io/mvisonneau/s5:latest-armv7"
+      - 'docker.io/mvisonneau/s5:latest-armv7'
+      - 'ghcr.io/mvisonneau/s5:latest-armv7'
+      - 'quay.io/mvisonneau/s5:latest-armv7'
     ids: [s5]
     goarch: arm
     goarm: 7
@@ -186,16 +186,16 @@ signs:
   - artifacts: checksum
     args:
       [
-        "-u",
-        "C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE",
-        "--output",
-        "${signature}",
-        "--detach-sign",
-        "${artifact}",
+        '-u',
+        'C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE',
+        '--output',
+        '${signature}',
+        '--detach-sign',
+        '${artifact}',
       ]
 
 checksum:
-  name_template: "{{ .ProjectName }}_edge_sha512sums.txt"
+  name_template: '{{ .ProjectName }}_edge_sha512sums.txt'
   algorithm: sha512
 
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - make man-pages
@@ -31,7 +32,7 @@ universal_binaries:
   - {}
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
         format: zip
@@ -46,7 +47,7 @@ nfpms:
     license: &license Apache-2.0
     homepage: &homepage https://github.com/mvisonneau/s5
     vendor: *author
-    file_name_template: '{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    file_name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     bindir: /usr/local/sbin
     formats:
       - apk
@@ -58,7 +59,7 @@ nfpms:
         file_info:
           mode: 0644
       - src: ./helpers/autocomplete/zsh
-        dst:  /usr/share/zsh/vendor-completions/_{{ .ProjectName }}
+        dst: /usr/share/zsh/vendor-completions/_{{ .ProjectName }}
         file_info:
           mode: 0644
       - src: ./helpers/manpages/{{ .ProjectName }}.1.gz
@@ -74,7 +75,7 @@ brews:
   - description: *description
     homepage: *homepage
     license: *license
-    folder: Formula
+    directory: Formula
     repository:
       owner: mvisonneau
       name: homebrew-tap
@@ -105,9 +106,9 @@ snapcrafts:
 
 dockers:
   - image_templates:
-      - 'docker.io/mvisonneau/s5:{{ .Tag }}-amd64'
-      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-amd64'
-      - 'quay.io/mvisonneau/s5:{{ .Tag }}-amd64'
+      - "docker.io/mvisonneau/s5:{{ .Tag }}-amd64"
+      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-amd64"
+      - "quay.io/mvisonneau/s5:{{ .Tag }}-amd64"
     ids: [s5]
     goarch: amd64
     use: buildx
@@ -123,9 +124,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - 'docker.io/mvisonneau/s5:{{ .Tag }}-arm64'
-      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-arm64'
-      - 'quay.io/mvisonneau/s5:{{ .Tag }}-arm64'
+      - "docker.io/mvisonneau/s5:{{ .Tag }}-arm64"
+      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-arm64"
+      - "quay.io/mvisonneau/s5:{{ .Tag }}-arm64"
     ids: [s5]
     goarch: arm64
     use: buildx
@@ -141,9 +142,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - 'docker.io/mvisonneau/s5:{{ .Tag }}-armv6'
-      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-armv6'
-      - 'quay.io/mvisonneau/s5:{{ .Tag }}-armv6'
+      - "docker.io/mvisonneau/s5:{{ .Tag }}-armv6"
+      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-armv6"
+      - "quay.io/mvisonneau/s5:{{ .Tag }}-armv6"
     ids: [s5]
     goarch: arm
     goarm: 6
@@ -160,9 +161,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - 'docker.io/mvisonneau/s5:{{ .Tag }}-armv7'
-      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-armv7'
-      - 'quay.io/mvisonneau/s5:{{ .Tag }}-armv7'
+      - "docker.io/mvisonneau/s5:{{ .Tag }}-armv7"
+      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-armv7"
+      - "quay.io/mvisonneau/s5:{{ .Tag }}-armv7"
     ids: [s5]
     goarch: arm
     goarm: 7
@@ -201,19 +202,19 @@ docker_manifests:
       - quay.io/mvisonneau/s5:{{ .Tag }}-armv7
 
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Tag }}_sha512sums.txt'
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_sha512sums.txt"
   algorithm: sha512
 
 signs:
   - artifacts: checksum
     args:
       [
-        '-u',
-        'C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE',
-        '--output',
-        '${signature}',
-        '--detach-sign',
-        '${artifact}',
+        "-u",
+        "C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE",
+        "--output",
+        "${signature}",
+        "--detach-sign",
+        "${artifact}",
       ]
 
 changelog:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ universal_binaries:
   - {}
 
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  - name_template: '{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
         format: zip
@@ -47,7 +47,7 @@ nfpms:
     license: &license Apache-2.0
     homepage: &homepage https://github.com/mvisonneau/s5
     vendor: *author
-    file_name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    file_name_template: '{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     bindir: /usr/local/sbin
     formats:
       - apk
@@ -106,9 +106,9 @@ snapcrafts:
 
 dockers:
   - image_templates:
-      - "docker.io/mvisonneau/s5:{{ .Tag }}-amd64"
-      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-amd64"
-      - "quay.io/mvisonneau/s5:{{ .Tag }}-amd64"
+      - 'docker.io/mvisonneau/s5:{{ .Tag }}-amd64'
+      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-amd64'
+      - 'quay.io/mvisonneau/s5:{{ .Tag }}-amd64'
     ids: [s5]
     goarch: amd64
     use: buildx
@@ -124,9 +124,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - "docker.io/mvisonneau/s5:{{ .Tag }}-arm64"
-      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-arm64"
-      - "quay.io/mvisonneau/s5:{{ .Tag }}-arm64"
+      - 'docker.io/mvisonneau/s5:{{ .Tag }}-arm64'
+      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-arm64'
+      - 'quay.io/mvisonneau/s5:{{ .Tag }}-arm64'
     ids: [s5]
     goarch: arm64
     use: buildx
@@ -142,9 +142,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - "docker.io/mvisonneau/s5:{{ .Tag }}-armv6"
-      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-armv6"
-      - "quay.io/mvisonneau/s5:{{ .Tag }}-armv6"
+      - 'docker.io/mvisonneau/s5:{{ .Tag }}-armv6'
+      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-armv6'
+      - 'quay.io/mvisonneau/s5:{{ .Tag }}-armv6'
     ids: [s5]
     goarch: arm
     goarm: 6
@@ -161,9 +161,9 @@ dockers:
       - --label=org.opencontainers.image.licenses=Apache-2.0
 
   - image_templates:
-      - "docker.io/mvisonneau/s5:{{ .Tag }}-armv7"
-      - "ghcr.io/mvisonneau/s5:{{ .Tag }}-armv7"
-      - "quay.io/mvisonneau/s5:{{ .Tag }}-armv7"
+      - 'docker.io/mvisonneau/s5:{{ .Tag }}-armv7'
+      - 'ghcr.io/mvisonneau/s5:{{ .Tag }}-armv7'
+      - 'quay.io/mvisonneau/s5:{{ .Tag }}-armv7'
     ids: [s5]
     goarch: arm
     goarm: 7
@@ -202,19 +202,19 @@ docker_manifests:
       - quay.io/mvisonneau/s5:{{ .Tag }}-armv7
 
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Tag }}_sha512sums.txt"
+  name_template: '{{ .ProjectName }}_{{ .Tag }}_sha512sums.txt'
   algorithm: sha512
 
 signs:
   - artifacts: checksum
     args:
       [
-        "-u",
-        "C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE",
-        "--output",
-        "${signature}",
-        "--detach-sign",
-        "${artifact}",
+        '-u',
+        'C09CA9F71C5C988E65E3E5FCADEA38EDC46F25BE',
+        '--output',
+        '${signature}',
+        '--detach-sign',
+        '${artifact}',
       ]
 
 changelog:


### PR DESCRIPTION
The release v0.1.14 failed due to the lack of GoReleaser.

https://github.com/mvisonneau/s5/releases/tag/v0.1.14

<img width="314" alt="image" src="https://github.com/user-attachments/assets/baa1d2e4-ccd1-4911-ba81-cf05af583828">

The release workflow failed.

https://github.com/mvisonneau/s5/actions/runs/11068634866/job/30754500864

```
Run make release
mkdir -p /home/runner/.cache/snapcraft/download
mkdir -p /home/runner/.cache/snapcraft/stage-packages
git tag -d edge
Deleted tag 'edge' (was 76[9](https://github.com/mvisonneau/s5/actions/runs/11068634866/job/30754500864#step:11:10)6960)
goreleaser release --clean
make: goreleaser: No such file or directory
make: *** [Makefile:39: release] Error [12](https://github.com/mvisonneau/s5/actions/runs/11068634866/job/30754500864#step:11:13)7
Error: Process completed with exit code 2.
```

GoReleaser was removed by this commit. https://github.com/mvisonneau/s5/commit/a054bbdf28ef6b022ae723bc3530c74f0551e002
I'm not sure why you removed GoReleaser, but GoReleaser is still necessary to release.