### PR TITLE
feat: support 1password secret references for the AES key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [0ver](https://0ver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Support for [1Password secret references](examples/1password.md) (`op://<vault>/<item>[/<section>]/<field>`) as
+  a value for the AES key, resolved at runtime through the `op` CLI
+
 ## [v0.1.13] - 2024-03-04
 
 - Implemented `golangci`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@
 - [Hashicorp Vault](https://www.vaultproject.io) - [Transit secret engine](https://www.vaultproject.io/docs/secrets/transit/index.html) ([example usage](examples/vault.md))
 - [PGP](https://www.openpgp.org/) ([example usage](examples/pgp.md))
 
+## Secret references
+
+Instead of passing the AES key itself, you can point `s5` at a [1Password](https://1password.com) secret reference (`op://<vault>/<item>/<field>`) and keep the key out of your shell profile and environment entirely ([example usage](examples/1password.md))
+
+```bash
+~$ export S5_AES_KEY="op://Private/s5/credential"
+```
+
+It requires the [1Password CLI](https://developer.1password.com/docs/cli/get-started/) (`op`) to be installed. Values that do not start with `op://` keep being used as-is.
+
 ## TL:DR
 
 Example using AES-GCM as the encryption backend

--- a/examples/1password.md
+++ b/examples/1password.md
@@ -1,0 +1,89 @@
+# 1Password
+
+Any secret that `s5` accepts on the command line (currently the AES key) can be
+replaced by a [1Password secret reference](https://developer.1password.com/docs/cli/secret-reference-syntax/),
+so that it never has to be stored in your shell profile, your environment or on
+disk.
+
+`s5` resolves those references by invoking the [1Password CLI](https://developer.1password.com/docs/cli/get-started/)
+(`op`), which therefore needs to be installed, available in your `PATH` and
+signed in. On a workstation this usually means enabling the desktop app
+integration (**1Password → Settings → Developer → Integrate with 1Password
+CLI**).
+
+## Store the key in 1Password
+
+Any item type works, `op read` returns whichever field you point it at. Keep the
+field **concealed** (`[password]`) rather than plain text: it gets masked in the
+UI and keeps a value history, so rotating the key does not lose the previous one
+while older ciphered files still refer to it.
+
+Using the `API Credential` category, which is meant for this kind of secret
+
+```bash
+~$ op item create \
+  --category="API Credential" \
+  --vault=Private \
+  --title=s5 \
+  "credential[password]=$(openssl rand -hex 32)"
+```
+
+Or the `Password` category, which lets you name the field yourself and holds
+several keys on a single item
+
+```bash
+~$ op item create \
+  --category=password \
+  --vault=Private \
+  --title=s5 \
+  "aes-key[password]=$(openssl rand -hex 32)"
+```
+
+In both cases the key itself never lands in your shell history, only the
+`openssl` command does. You can then get the reference of the field with
+
+```bash
+~$ op item get s5 --vault=Private --format json | jq -r '.fields[] | select(.value != null) | .reference'
+op://Private/s5/credential
+```
+
+## Usage
+
+Use the reference wherever you used to pass the key itself
+
+```bash
+~$ s5 cipher aes --key "op://Private/s5/credential" foo
+{{s5:YTdlOTQ2M2VhNzE1MGQ3NzlkYTRkZGRhOTM1MjEzMDBkOTNjNzY6ODhhNzI2NGUzZTllZjgwYTAyNWVhOWRm}}
+```
+
+Or, more conveniently, export the reference instead of the key. Contrary to the
+key, the reference is not sensitive and can safely live in your `~/.zshrc`,
+`~/.bashrc` or in a committed `.envrc`
+
+```bash
+~$ export S5_AES_KEY="op://Private/s5/credential"
+~$ echo "foo" | s5 cipher aes | s5 decipher aes
+foo
+```
+
+The value is only fetched when a command actually needs it, and 1Password
+unlocks it the way it is configured to: through Touch ID / the desktop app when
+you are on a workstation, and using `OP_SERVICE_ACCOUNT_TOKEN` when running
+unattended, eg: in CI
+
+```bash
+~$ export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+~$ export S5_AES_KEY="op://CI/s5/credential"
+~$ s5 render aes example.yml
+```
+
+## Reference syntax
+
+```
+op://<vault>/<item>/<field>
+op://<vault>/<item>/<section>/<field>
+```
+
+Vault, item and field names may contain spaces, in which case the reference
+needs to be quoted. Values that do not start with `op://` are used as-is, so
+this is entirely opt-in and does not change any existing setup.

--- a/examples/aes-gcm.md
+++ b/examples/aes-gcm.md
@@ -36,6 +36,13 @@ Otherwise you will need to use the `--key` flag on each of your commands
 ~$ s5 cipher aes --key 0b9f3051e89ba4d5018fc7fb96fe5b44 "foo"
 ```
 
+Storing the key in plaintext is however not great, if you use 1Password you can
+store it there and refer to it instead, see [1password.md](1password.md)
+
+```bash
+~$ export S5_AES_KEY="op://Private/s5/credential"
+```
+
 ## Usage
 
 ```bash

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.12.1
 	github.com/urfave/cli/v3 v3.11.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/term v0.45.0
 )
 
 require (
@@ -489,7 +490,6 @@ require (
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -49,6 +49,11 @@ func TestCipher(t *testing.T) {
 			arguments: []string{"s5", "cipher", "aes", "--key"},
 			expectErr: "flag needs an argument: --key",
 		},
+		{
+			name:      "invalid 1password secret reference",
+			arguments: []string{"s5", "cipher", "aes", "--key", "op://Personal", "coucou"},
+			expectErr: "invalid 1password secret reference",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -8,7 +8,7 @@ var aesFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "key",
 		Sources: cli.EnvVars("S5_AES_KEY"),
-		Usage:   "`path` to a readable key for AES encryption/decryption",
+		Usage:   "hexadecimal `key` for AES, or a 1password secret reference to it (op://<vault>/<item>/<field>)",
 	},
 }
 

--- a/internal/cmd/utils.go
+++ b/internal/cmd/utils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mvisonneau/s5/internal/logs"
 	"github.com/mvisonneau/s5/pkg/cipher"
+	"github.com/mvisonneau/s5/pkg/onepassword"
 )
 
 func configure(ctx context.Context, cmd *cli.Command) (context.Context, error) {
@@ -37,7 +38,11 @@ func getCipherEngine(ctx context.Context, cmd *cli.Command) (engine cipher.Engin
 	cmds := cmd.Names()
 	switch cmds[len(cmds)-1] {
 	case "aes":
-		engine, err = cipher.NewAESClient(cmd.String("key"))
+		var key string
+
+		if key, err = resolveSecret(ctx, cmd.String("key")); err == nil {
+			engine, err = cipher.NewAESClient(key)
+		}
 	case "aws":
 		engine, err = cipher.NewAWSClient(ctx, cmd.String("kms-key-arn"))
 	case "gcp":
@@ -55,6 +60,16 @@ func getCipherEngine(ctx context.Context, cmd *cli.Command) (engine cipher.Engin
 	}
 
 	return
+}
+
+// resolveSecret returns a value as provided, unless it holds a 1Password secret
+// reference, in which case it gets resolved against 1Password.
+func resolveSecret(ctx context.Context, value string) (string, error) {
+	if !onepassword.IsSecretReference(value) {
+		return value, nil
+	}
+
+	return onepassword.Read(ctx, value)
 }
 
 func readInput(cmd *cli.Command) (input string, err error) {

--- a/pkg/onepassword/onepassword.go
+++ b/pkg/onepassword/onepassword.go
@@ -1,0 +1,101 @@
+// Package onepassword resolves 1Password secret references, allowing secrets
+// used by s5 to be kept in 1Password rather than in environment variables or
+// files. References are resolved by shelling out to the `op` CLI, which means
+// they can be unlocked interactively (biometrics, desktop app integration) or
+// non-interactively through a service account token.
+package onepassword
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"golang.org/x/term"
+
+	"github.com/mvisonneau/s5/internal/logs"
+)
+
+const (
+	// SecretReferenceScheme is the prefix of a 1Password secret reference.
+	SecretReferenceScheme string = "op://"
+
+	// CLI is the name of the 1Password command line binary.
+	CLI string = "op"
+
+	// segment is a single, non blank, component of a secret reference. Vault,
+	// item and field names may contain spaces and fields can hold query
+	// parameters, eg: op://prod/db/one-time password?attribute=otp.
+	segment string = `[^/\r\n]*[^\s/][^/\r\n]*`
+)
+
+// SecretReferenceRegexp is defining the syntax of a 1Password secret
+// reference: op://<vault>/<item>[/<section>]/<field>.
+var SecretReferenceRegexp = regexp.MustCompile(`^op://` + segment + `(/` + segment + `){2,3}$`)
+
+// execCommandContext is a variable in order to be able to fake the `op` CLI
+// within the tests.
+var execCommandContext = exec.CommandContext
+
+// IsSecretReference returns whether a value is a 1Password secret reference.
+func IsSecretReference(value string) bool {
+	return strings.HasPrefix(value, SecretReferenceScheme)
+}
+
+// Read resolves a 1Password secret reference and returns its value.
+func Read(ctx context.Context, reference string) (string, error) {
+	logs.LoggerFromContext(ctx).Debug(
+		"resolving a 1password secret reference",
+		zap.String("reference", reference),
+	)
+
+	if !SecretReferenceRegexp.MatchString(reference) {
+		return "", errors.Errorf(
+			"invalid 1password secret reference '%s', should be '%s<vault>/<item>[/<section>]/<field>'",
+			reference,
+			SecretReferenceScheme,
+		)
+	}
+
+	var stdout, stderr bytes.Buffer
+
+	// #nosec G204 -- the reference is validated above and passed as an argument,
+	// no shell is involved.
+	c := execCommandContext(ctx, CLI, "read", "--no-newline", reference)
+	c.Stdout = &stdout
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		// hand over the terminal so that the CLI remains able to prompt for
+		// credentials.
+		c.Stdin = os.Stdin
+		c.Stderr = os.Stderr
+	} else {
+		// the CLI must not consume the stdin of s5, which may hold the content
+		// to (de)cipher.
+		c.Stdin = nil
+		c.Stderr = &stderr
+	}
+
+	if err := c.Run(); err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", errors.Wrapf(err, "the '%s' cli is required in order to resolve 1password secret references", CLI)
+		}
+
+		if msg := strings.TrimSpace(stderr.String()); len(msg) > 0 {
+			return "", errors.Wrapf(err, "reading '%s' from 1password: %s", reference, msg)
+		}
+
+		return "", errors.Wrapf(err, "reading '%s' from 1password", reference)
+	}
+
+	value := strings.TrimSpace(stdout.String())
+	if len(value) == 0 {
+		return "", errors.Errorf("1password returned an empty value for '%s'", reference)
+	}
+
+	return value, nil
+}

--- a/pkg/onepassword/onepassword_test.go
+++ b/pkg/onepassword/onepassword_test.go
@@ -1,0 +1,153 @@
+package onepassword
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	helperProcessEnv = "S5_WANT_HELPER_PROCESS"
+	validReference   = "op://Personal/s5/aes-key"
+)
+
+// TestHelperProcess is not a real test, it impersonates the `op` CLI when
+// executed through fakeCLI().
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv(helperProcessEnv) != "1" {
+		return
+	}
+
+	_, _ = fmt.Fprint(os.Stdout, os.Getenv("S5_HELPER_STDOUT"))
+	_, _ = fmt.Fprint(os.Stderr, os.Getenv("S5_HELPER_STDERR"))
+
+	exitCode, _ := strconv.Atoi(os.Getenv("S5_HELPER_EXIT_CODE"))
+
+	os.Exit(exitCode)
+}
+
+// fakeCLI replaces the `op` CLI with the test binary itself, which returns the
+// provided stdout, stderr and exit code. It also records the arguments the CLI
+// got called with.
+func fakeCLI(t *testing.T, stdout, stderr string, exitCode int) *[]string {
+	t.Helper()
+
+	var args []string
+
+	original := execCommandContext
+
+	execCommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		args = append([]string{name}, arg...)
+
+		// #nosec G204 -- we are executing the test binary itself
+		c := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHelperProcess$", "-test.v=false")
+		c.Env = append(os.Environ(),
+			helperProcessEnv+"=1",
+			"S5_HELPER_STDOUT="+stdout,
+			"S5_HELPER_STDERR="+stderr,
+			"S5_HELPER_EXIT_CODE="+strconv.Itoa(exitCode),
+		)
+
+		return c
+	}
+
+	t.Cleanup(func() {
+		execCommandContext = original
+	})
+
+	return &args
+}
+
+func TestIsSecretReference(t *testing.T) {
+	assert.True(t, IsSecretReference(validReference))
+	assert.True(t, IsSecretReference("op://Personal/s5/section/aes-key"))
+	assert.False(t, IsSecretReference("cc6af4c2bf251c1cce0aebdbd39dc91d"))
+	assert.False(t, IsSecretReference(""))
+	assert.False(t, IsSecretReference("/op://Personal/s5/aes-key"))
+}
+
+func TestReadInvalidReference(t *testing.T) {
+	args := fakeCLI(t, "foo", "", 0)
+
+	for _, reference := range []string{
+		"op://",
+		"op://Personal",
+		"op://Personal/s5",
+		"op://Personal/s5/section/subsection/aes-key",
+		"op://Personal/s5/ ",
+		"op://Personal//aes-key",
+	} {
+		value, err := Read(context.TODO(), reference)
+		require.ErrorContains(t, err, "invalid 1password secret reference")
+		assert.Empty(t, value)
+	}
+
+	// the CLI should not have been executed at all
+	assert.Empty(t, *args)
+}
+
+func TestReadReferenceWithSpacesAndQueryParameters(t *testing.T) {
+	args := fakeCLI(t, "cc6af4c2bf251c1cce0aebdbd39dc91d", "", 0)
+
+	reference := "op://Private Vault/my s5 item/section/one-time password?attribute=otp"
+
+	value, err := Read(context.TODO(), reference)
+	require.NoError(t, err)
+	assert.Equal(t, "cc6af4c2bf251c1cce0aebdbd39dc91d", value)
+	assert.Equal(t, []string{CLI, "read", "--no-newline", reference}, *args)
+}
+
+func TestReadValidReference(t *testing.T) {
+	args := fakeCLI(t, "cc6af4c2bf251c1cce0aebdbd39dc91d\n", "", 0)
+
+	value, err := Read(context.TODO(), validReference)
+	require.NoError(t, err)
+	assert.Equal(t, "cc6af4c2bf251c1cce0aebdbd39dc91d", value)
+	assert.Equal(t, []string{CLI, "read", "--no-newline", validReference}, *args)
+}
+
+func TestReadEmptyValue(t *testing.T) {
+	fakeCLI(t, "  \n", "", 0)
+
+	value, err := Read(context.TODO(), validReference)
+	require.ErrorContains(t, err, "1password returned an empty value")
+	assert.Empty(t, value)
+}
+
+func TestReadCLIError(t *testing.T) {
+	fakeCLI(t, "", "[ERROR] could not read secret: not found\n", 1)
+
+	value, err := Read(context.TODO(), validReference)
+	require.ErrorContains(t, err, "could not read secret: not found")
+	assert.Empty(t, value)
+}
+
+func TestReadCLIErrorWithoutStderr(t *testing.T) {
+	fakeCLI(t, "", "", 1)
+
+	value, err := Read(context.TODO(), validReference)
+	require.ErrorContains(t, err, "reading '"+validReference+"' from 1password")
+	assert.Empty(t, value)
+}
+
+func TestReadCLINotFound(t *testing.T) {
+	original := execCommandContext
+
+	execCommandContext = func(ctx context.Context, _ string, arg ...string) *exec.Cmd {
+		return exec.CommandContext(ctx, "s5-tests-op-cli-which-does-not-exist", arg...)
+	}
+
+	t.Cleanup(func() {
+		execCommandContext = original
+	})
+
+	value, err := Read(context.TODO(), validReference)
+	require.ErrorContains(t, err, "the 'op' cli is required")
+	assert.Empty(t, value)
+}


### PR DESCRIPTION
Storing the AES key in a shell profile or an environment variable means keeping it in plaintext. Any value that starts with `op://` is now treated as a 1Password secret reference and resolved at runtime through the `op` CLI, so only the (non sensitive) reference needs to be stored:

  export S5_AES_KEY="op://Private/s5/aes-key"

1Password unlocks the value the way it is configured to: biometrics or the desktop app when working interactively, OP_SERVICE_ACCOUNT_TOKEN when running unattended. Values that do not start with `op://` keep being used as-is, making this entirely opt-in.

The resolution happens in a dedicated package, behind a helper which can be reused for the other secrets s5 handles (eg: the Vault token) later on.